### PR TITLE
Replaces log4php usage completely with PSR logger

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,6 @@
     "doctrine/cache":"1.4.*"
   },
   "require-dev": {
-    "apache/log4php": "2.3.*",
     "psr/log": "^1.0 || ^2.0 || ^3.0",
     "phpunit/phpunit": "^9.3"
   },

--- a/src/main/php/com-realexpayments-hpp-sdk/RXPLogger.php
+++ b/src/main/php/com-realexpayments-hpp-sdk/RXPLogger.php
@@ -2,7 +2,7 @@
 
 namespace com\realexpayments\hpp\sdk;
 
-use Logger;
+use Psr\Log\NullLogger;
 
 /**
  * Class RXPLogger. Wraps initialisation of the logging framework
@@ -12,11 +12,7 @@ use Logger;
 class RXPLogger
 {
     /**
-     * @var bool
-     */
-    private static $initialised = false;
-
-    /* @var \Psr\Log\LoggerInterface|null
+     * @var \Psr\Log\LoggerInterface|null
      */
     private static $psrLogger = null;
 
@@ -30,42 +26,15 @@ class RXPLogger
     }
 
     /**
-     * @param string $className
-     *
-     * @return Logger|\Psr\Log\LoggerInterface
+     * @return \Psr\Log\LoggerInterface
      */
-    public static function GetLogger($className)
+    public static function GetLogger()
     {
         if (self::$psrLogger !== null) {
             return self::$psrLogger;
         }
 
-        if (!self::IsInitialised()) {
-            self::Initialise();
-        }
-
-        return Logger::getLogger($className);
-    }
-
-    private static function Initialise()
-    {
-        if (!class_exists("\Logger")) {
-            throw new \RuntimeException('Neither the Logger is set, nor is apache/log4php library installed');
-        }
-
-        $path = $_SERVER['DOCUMENT_ROOT'] . '/config.xml';
-        if (file_exists($path)) {
-            Logger::configure($path);
-        } else {
-            Logger::configure(__DIR__ . '/config.xml');
-        }
-
-        self::$initialised = true;
-    }
-
-    private static function IsInitialised()
-    {
-        return self::$initialised;
+        return new NullLogger();
     }
 
 }

--- a/src/main/php/com-realexpayments-hpp-sdk/RealexHpp.php
+++ b/src/main/php/com-realexpayments-hpp-sdk/RealexHpp.php
@@ -7,8 +7,6 @@ use com\realexpayments\hpp\sdk\domain\HppResponse;
 use com\realexpayments\hpp\sdk\utils\JsonUtils;
 use com\realexpayments\hpp\sdk\utils\ValidationUtils;
 use Exception;
-use Logger;
-
 
 /**
  * <p>
@@ -30,6 +28,7 @@ use Logger;
  * $hppResponse = $realexHpp->responseFromJson($responseJson);
  * </pre></code>
  * </p>
+ *
  * @author vicpada
  *
  */
@@ -37,7 +36,7 @@ class RealexHpp
 {
 
     /**
-     * @var Logger|\Psr\Log\LoggerInterface
+     * @var \Psr\Log\LoggerInterface
      */
     private $logger;
 
@@ -45,7 +44,6 @@ class RealexHpp
      * Character set to use for encoding/decoding.
      */
     const ENCODING_CHARSET = "UTF-8";
-
 
     /**
      * @var string  The shared secret issued by Realex. Used to create the SHA-1 hash in the request and
@@ -60,7 +58,7 @@ class RealexHpp
      */
     public function __construct($secret)
     {
-        $this->logger = RXPLogger::getLogger(__CLASS__);
+        $this->logger = RXPLogger::getLogger();
         $this->secret = $secret;
     }
 
@@ -98,13 +96,15 @@ class RealexHpp
         $this->logger->debug("Encoding object.");
         try {
             if ($encoded === true) {
-                $hppRequest = $hppRequest->encode(self::ENCODING_CHARSET);              
-            }
-            else {
+                $hppRequest = $hppRequest->encode(self::ENCODING_CHARSET);
+            } else {
                 $hppRequest = $hppRequest->formatRequest(self::ENCODING_CHARSET);
             }
         } catch (Exception $e) {
-            $this->logError("Exception encoding HPP request.", $e);
+            $this->logger->error("Exception encoding HPP request.", [
+                'exception' => $e->getMessage(),
+                'trace' => $e->getTrace(),
+            ]);
             throw new RealexException("Exception encoding HPP request.", $e);
         }
 
@@ -113,20 +113,6 @@ class RealexHpp
         $json = JsonUtils::toJson($hppRequest);
 
         return $json;
-    }
-
-    /**
-     * @param string $message
-     * @param \Exception $e
-     * @return void
-     */
-    private function logError(string $message, \Exception $e)
-    {
-        if ($this->logger instanceof \Psr\Log\LoggerInterface) {
-            $this->logger->error($message, ['exception' => $e->getMessage(), 'trace' => $e->getTrace()]);
-            return;
-        }
-        $this->logger->error($message, $e);
     }
 
     /**
@@ -144,7 +130,7 @@ class RealexHpp
      * @param bool $encoded <code>true</code> if the JSON values have been encoded.
      * @return HppRequest
      */
-    public function  requestFromJson($json, $encoded = true)
+    public function requestFromJson($json, $encoded = true)
     {
         $this->logger->info("Converting JSON to HppRequest.");
 
@@ -157,7 +143,10 @@ class RealexHpp
             try {
                 $hppRequest = $hppRequest->decode(self::ENCODING_CHARSET);
             } catch (Exception $e) {
-                $this->logError("Exception encoding HPP request.", $e);
+                $this->logger->error("Exception encoding HPP request.", [
+                    'exception' => $e->getMessage(),
+                    'trace' => $e->getTrace(),
+                ]);
                 throw new RealexException("Exception decoding HPP request.", $e);
             }
         }
@@ -186,7 +175,6 @@ class RealexHpp
      */
     public function responseToJson(HppResponse $hppResponse)
     {
-
         $this->logger->info("Converting HppResponse to JSON.");
 
         $json = null;
@@ -200,7 +188,10 @@ class RealexHpp
         try {
             $hppResponse = $hppResponse->encode(self::ENCODING_CHARSET);
         } catch (Exception $e) {
-            $this->logError("Exception encoding HPP response.", $e);
+            $this->logger->error("Exception encoding HPP response.", [
+                'exception' => $e->getMessage(),
+                'trace' => $e->getTrace(),
+            ]);
             throw new RealexException("Exception encoding HPP response.", $e);
         }
 
@@ -239,7 +230,10 @@ class RealexHpp
             try {
                 $hppResponse = $hppResponse->decode(self::ENCODING_CHARSET);
             } catch (Exception $e) {
-                $this->logError("Exception decoding HPP response.", $e);
+                $this->logger->error("Exception decoding HPP response.", [
+                    'exception' => $e->getMessage(),
+                    'trace' => $e->getTrace(),
+                ]);
                 throw new RealexException("Exception decoding HPP response.", $e);
             }
         }

--- a/src/main/php/com-realexpayments-hpp-sdk/utils/ValidationUtils.php
+++ b/src/main/php/com-realexpayments-hpp-sdk/utils/ValidationUtils.php
@@ -9,7 +9,6 @@ use com\realexpayments\hpp\sdk\domain\HppResponse;
 use com\realexpayments\hpp\sdk\RealexValidationException;
 use com\realexpayments\hpp\sdk\RXPLogger;
 use Doctrine\Common\Annotations\AnnotationRegistry;
-use Logger;
 use Symfony\Component\Validator\ConstraintViolationInterface;
 use Symfony\Component\Validator\Validation;
 use Symfony\Component\Validator\Validator\ValidatorInterface;
@@ -23,7 +22,7 @@ use Symfony\Component\Validator\Validator\ValidatorInterface;
 class ValidationUtils {
 
     /**
-     * @var Logger|\Psr\Log\LoggerInterface|null
+     * @var \Psr\Log\LoggerInterface|null
      */
 	private static $logger;
 	private static $initialised = false;
@@ -57,7 +56,7 @@ class ValidationUtils {
 				$message .= $validationMessage . '.';
 			}
 
-			self::$logger->info( $message );
+			self::$logger->info($message);
 			throw new RealexValidationException( "HppRequest failed validation", $validationMessages );
 		}
 
@@ -73,7 +72,7 @@ class ValidationUtils {
 
 		AnnotationRegistry::registerLoader( array( $loader, 'loadClass' ) );
 
-		self::$logger = RXPLogger::getLogger( __CLASS__ );
+		self::$logger = RXPLogger::getLogger();
 
 		self::$validator = Validation::createValidatorBuilder()
 		                             ->enableAnnotationMapping()


### PR DESCRIPTION
Chances of someone using log4php still and _wanting_ to keep using it are slim. Chances of them using this specific fork are even slimmer.

And a full switchover to only PSR logger interface makes it easier to inspect the code to avoid any pitfals like using the ->trace method. Or using ->warn (which isn't part of the PSR interface, but would work with Monolog 1.x).

Related:
https://github.com/DocnetUK/rxp-remote-php/pull/13